### PR TITLE
Implement mission joining, leaving and switching badges

### DIFF
--- a/src/components/Mission.js
+++ b/src/components/Mission.js
@@ -12,12 +12,10 @@ useEffect(() => {
 }, []);
 
 const showMission = useSelector(state => state.Mission)
-console.log(showMission)
 
 const handleClick = (e) => {
   let payload = e.target.id
   dispatch(joinMission(payload))
-  console.log(showMission)
   }
 
 return (
@@ -29,9 +27,18 @@ return (
          <li className='name-cell'>{mission.mission_name}</li>
          <li className='description-cell'>{mission.description}</li> 
           {!mission.join_mission &&
-          <button id={mission.mission_id} onClick={(e) => handleClick(e)}>Remove</button>}
+          <div>
+          <button type='button'>NOT A MEMBER</button>
+          <button type='button' id={mission.mission_id} onClick={(e) => handleClick(e)}>JOIN MISSION</button>
+          </div>
+          }
+          
           {mission.join_mission &&
-          <button id={mission.mission_id} onClick={(e) => handleClick(e)}>Delete</button>}   
+          <div>
+            <button type='button'>ACTIVE MEMBER</button>
+          <button type='button' id={mission.mission_id} onClick={(e) => handleClick(e)}>LEAVE MISSION</button>
+          </div>
+          }   
         </ul>
       
        

--- a/src/components/Mission.js
+++ b/src/components/Mission.js
@@ -1,6 +1,7 @@
 import {useDispatch, useSelector} from 'react-redux'
 import React, { useEffect } from 'react';
-import { getMissions } from '../redux/missions/missionAction';
+import { getMissions, joinMission } from '../redux/missions/missionAction';
+
 
 const Mission = () => {
 
@@ -11,17 +12,30 @@ useEffect(() => {
 }, []);
 
 const showMission = useSelector(state => state.Mission)
+console.log(showMission)
+
+const handleClick = (e) => {
+  let payload = e.target.id
+  dispatch(joinMission(payload))
+  console.log(showMission)
+  }
+
 return (
-  <div >      
-      {showMission.map(mission => ( 
-                
+  <div > 
+       
+      {showMission.map(mission => (      
+        
         <ul className='wrapper' key={mission.mission_id}>
          <li className='name-cell'>{mission.mission_name}</li>
-         <li className='description-cell'>{mission.description}</li>  
-               
+         <li className='description-cell'>{mission.description}</li> 
+          {!mission.join_mission &&
+          <button id={mission.mission_id} onClick={(e) => handleClick(e)}>Remove</button>}
+          {mission.join_mission &&
+          <button id={mission.mission_id} onClick={(e) => handleClick(e)}>Delete</button>}   
         </ul>
       
-      ))}
+       
+        ))}
    
 </div>
 )

--- a/src/redux/missions/missionReducer.js
+++ b/src/redux/missions/missionReducer.js
@@ -6,16 +6,22 @@ export default (state = mission, action) => {
       
       return action.payload;
     
-    case 'JOIN_MISSION':
-     state.map(item => {
-      if(item.mission_id === action.payload){
-        return {
-          ...state,
-          join_mission: !state.join_mission,
-        };
-      }
-     })
-
+    case 'JOIN_MISSION':      
+      let updatedItem;  
+      let index    
+      state.map((item, i) => {
+        if(item.mission_id === action.payload){
+          updatedItem = {...item, join_mission: !item.join_mission};
+          index = i
+        }      
+        
+      }) 
+      return [    
+             ...state.slice(0,index),
+              updatedItem,
+              ...state.slice(index+1)
+            ]     
+         
      default:
       return state
   }

--- a/src/redux/missions/missionReducer.js
+++ b/src/redux/missions/missionReducer.js
@@ -8,7 +8,7 @@ export default (state = mission, action) => {
     
     case 'JOIN_MISSION':      
       let updatedItem;  
-      let index    
+      let index;  
       state.map((item, i) => {
         if(item.mission_id === action.payload){
           updatedItem = {...item, join_mission: !item.join_mission};


### PR DESCRIPTION
In this milestone I have implemented the following:

- When a user clicks the "Join Mission" button, action is dispatched to update the store.
-  When a user clicks the "Leave Mission" button, action is dispatched to update the store.
- Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design)

Kindly review and approve.